### PR TITLE
添加秘境等级限制，防止出现秘境结算时temp_dict为空的情况

### DIFF
--- a/nonebot_plugin_xiuxian_2/xiuxian/xiuxian_rift/__init__.py
+++ b/nonebot_plugin_xiuxian_2/xiuxian/xiuxian_rift/__init__.py
@@ -23,7 +23,7 @@ from ..xiuxian_utils.utils import (
 )
 from .riftconfig import get_rift_config, savef_rift
 from .jsondata import save_rift_data, read_rift_data
-from ..xiuxian_config import XiuConfig
+from ..xiuxian_config import XiuConfig, convert_rank
 from .riftmake import (
     Rift, get_rift_type, get_story_type, NONEMSG, get_battle_type,
     get_dxsj_info, get_boss_battle_info, get_treasure_info
@@ -193,6 +193,15 @@ async def _(bot: Bot, event: GroupMessageEvent):
             await explore_rift.finish()
         if user_id in group_rift[group_id].l_user_id:
             msg = '道友已经参加过本次秘境啦，请把机会留给更多的道友！'
+            if XiuConfig().img:
+                pic = await get_msg_pic(f"@{event.sender.nickname}\n" + msg)
+                await bot.send_group_msg(group_id=int(send_group_id), message=MessageSegment.image(pic))
+            else:
+                await bot.send_group_msg(group_id=int(send_group_id), message=msg)
+            await explore_rift.finish()
+        
+        if convert_rank(user_info["level"])[0] > group_rift[group_id].rank:
+            msg = f"秘境凶险万分，道友的境界不足，无法进入秘境：{group_rift[group_id].name}，请道友提升到搬血境中期以上再来！"
             if XiuConfig().img:
                 pic = await get_msg_pic(f"@{event.sender.nickname}\n" + msg)
                 await bot.send_group_msg(group_id=int(send_group_id), message=MessageSegment.image(pic))


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 添加了一个限制，防止修为等级过低的用户进入裂隙。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Added a restriction that prevents users from entering rifts if their cultivation rank is too low.

</details>